### PR TITLE
Towards #206: Deploy docs via GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Deploy Sphinx documentation to Pages
+
+on:
+  push:
+    branches: [master] # branch to trigger deployment
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install .[docs]
+      - id: build
+        name: Build documentation
+        run: |
+          cd docs
+          make html
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/_build/html
+      
+  deploy-pages:
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
+      - name: Deploy artifact
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.project
 *.pydevproject
 *.settings
+.venv/
 
 *.swp
 *.swo

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install pycopancore
 ### Documentation
 Comprehensive documentation is available at: https://pik-copan.github.io/pycopancore
 
-See [examples](./examples/) for examples on how to use the framework.
+Example models can be found at [pik-copan/pycopanmodels](https://github.com/pik-copan/pycopanmodels).
 
 ## Questions / Problems
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -62,18 +62,15 @@ For running pycopancore, an installation with python > 3.6 with some additional 
 
 An easy way to install python is to use the `Anaconda environment <https://www.anaconda.com/download/>`_.
 
-The package can be installed by downloading the repository and and running the setup.py script with
+The package can be installed by downloading the repository and and running the setup.py script with::
 
-```
-$ pip install
-```
+    $ pip install
+
 from the root directory of the package. The script should automatically install all the required and missing packages.
 
-For developers, the recommended way of installing is to run in the package main directory
+For developers, the recommended way of installing is to run in the package main directory::
 
-```
-$ pip install -e
-```
+    $ pip install -e
 
 This creates a link instead of copying the files, so modifications in this directory are modifications in the installed package.
 
@@ -82,10 +79,9 @@ This creates a link instead of copying the files, so modifications in this direc
 Running a model
 ---------------
 
-To run one of the preconfigured models, execute a python script in the `studies` folder, for example
-```bash
-python run_seven_dwarfs.py
-```
+To run one of the preconfigured models, execute a python script in the `studies` folder, for example::
+
+    python run_seven_dwarfs.py
 
 .. _docu:
 
@@ -94,16 +90,15 @@ Documentation
 
 The documentation can be accessed under `https://pik-copan.github.io/pycopancore <https://pik-copan.github.io/pycopancore>`_ and provides an introduction to the framework, its different entity and process types, a full documentation of the API as well as a step-by-step tutorial.
 
-To create a local html version of the documentation, access the `docs` directory and type
-```
-> make html
-```
+To create a local html version of the documentation, access the `docs` directory and type::
+
+    > make html
+
 The documentation can then be accessed under `docs/_build/html/index.html`.
 
-To be able to create the automatic UML-Diagrams, `pylint <https://www.pylint.org/>`_ and `graphviz <http://www.graphviz.org/>`_ needs to be installed. To finally create the diagrams, use
-```
-> make uml
-```
+To be able to create the automatic UML-Diagrams, `pylint <https://www.pylint.org/>`_ and `graphviz <http://www.graphviz.org/>`_ needs to be installed. To finally create the diagrams, use::
+
+    > make uml
 
 .. _CoC:
 
@@ -132,10 +127,10 @@ Additional guidelines:
 Tests
 -----
 
-We are using the python testing framework `pytest <http://pytest.org/latest/>`_ with `pylama <https://github.com/klen/pylama>`_ for style and error checking. Please write corresponding unittests while developing and make sure that all test pass by executing
-```
-py.test
-```
+We are using the python testing framework `pytest <http://pytest.org/latest/>`_ with `pylama <https://github.com/klen/pylama>`_ for style and error checking. Please write corresponding unittests while developing and make sure that all test pass by executing::
+    
+    py.test
+
 in the root of the project tree.
 
 Requires

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dev = [
     "pytest-cov>=2.5.1",
     "pylama_pylint"
 ]
+docs = [
+    "sphinx"
+]
 
 [project.urls]
 Homepage = "https://github.com/pik-copan/pycopancore"


### PR DESCRIPTION
This GitHub workflow deploys the documentation and fixes the problems in #206. The example model components for the seven_dwarfs model should be removed before the next release for #206 to be finally closed.