### PR TITLE
Hotfix: Checkout code in build-docs GH action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Fetch all history and tags
         fetch-tags: true  # Ensure all tags are fetched for version resolution
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.9.25' # This must be matched to the version in the pyproject.toml
 
     - name: Install dependencies
       run: |
@@ -37,6 +37,7 @@ jobs:
     #     pytest --cov=pycopancore --cov-report=xml
 
     - name: Upload coverage reports to Codecov
+      if: ${{ !env.ACT }} # When testing the action with act (https://nektosact.com), this should not run.
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,12 +12,14 @@ jobs:
       pages: write
       id-token: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install dependencies
-        run: |
+        run: | 
           pip install .[docs]
       - id: build
         name: Build documentation
@@ -25,8 +27,10 @@ jobs:
           cd docs
           make html
       - name: Setup Pages
+        if: ${{ !env.ACT }} # When testing the action with act (https://nektosact.com), this should not run.
         uses: actions/configure-pages@v6
       - name: Upload GitHub Pages artifact
+        if: ${{ !env.ACT }}
         uses: actions/upload-pages-artifact@v4
         with:
           path: docs/_build/html
@@ -40,4 +44,4 @@ jobs:
     steps:
       - name: Deploy artifact
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Apparently, I forgot to add the `checkout` action, so the folder was empty.

I tested the new action locally with [act](https://nektosact.com) to prevent future failures.

I also updated the action version to address the node 24 warning and changed the python version in the check workflow to the minimum version from the `pyproject.toml`.