### PR TITLE
Fixes #211: Do not remove processes if missing from interface

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -59,6 +59,9 @@ authors:
   given-names: Paula
 - family-names: Prawitz
   given-names: Hannah
+- family-names: Sieben
+  given-names: Lorenz
+  orcid: 0009-0006-5307-9391
 
 license: BSD-2-Clause
 repository-code: https://github.com/pik-copan/pycopancore

--- a/pycopancore/model_components/base/model_logics.py
+++ b/pycopancore/model_components/base/model_logics.py
@@ -208,7 +208,7 @@ class ModelLogics (object):
                                 "different codename."
                 # find and register all processes defined directly in this
                 # mixin's "process" attribute:
-                if "processes" not in mixin_interface.__dict__:
+                if "processes" not in mixin.__dict__:
                     mixin.processes = []
 
                 for p in mixin.processes:


### PR DESCRIPTION
These changes should be released in the next patch version.

## Changes

- Bugfix #211: Processes are no longer removed in `ModelLogics.configure()`